### PR TITLE
Fix serialNumber parsing

### DIFF
--- a/android/src/main/java/com/example/sim_data_plus/SimDataPlugin.java
+++ b/android/src/main/java/com/example/sim_data_plus/SimDataPlugin.java
@@ -214,12 +214,12 @@ public class SimDataPlugin implements FlutterPlugin, MethodCallHandler, Activity
       //get serial number of sim card/s
       phoneAccountHandle = phoneAccounts.next();
       if(count==0){
-        card.put("serialNumber",phoneAccountHandle.getId().substring(0,19));
+        card.put("serialNumber",phoneAccountHandle.getId().replaceAll("[^\\d]", ""));
       }else{
-        card.put("serialNumber",phoneAccountHandle.getId().substring(0,19));
+        card.put("serialNumber",phoneAccountHandle.getId().replaceAll("[^\\d]", ""));
       }
       count++;
-      System.out.println("serial number - "+phoneAccountHandle.getId().substring(0,19));
+      System.out.println("serial number - "+phoneAccountHandle.getId().replaceAll("[^\\d]", ""));
 
       // }catch(Exception ex){
       //   System.out.println("Exception on TelecomManager");


### PR DESCRIPTION
'serialNumber' variable (ICCID) is a string that has 19 to 20 digits. Using substring(0, 19) for parsing is bad idea.
It's better idea to remove all non digits chars (depending on SIM card, sometimes plugin returns 19 digits + a char that is omitted in system settings).
This commit also fixes Android Emulator throwing exception (emulator serial number == "1" - which substring(0, 19) fails to parse)